### PR TITLE
chore(i18n): Add i18n library to manage translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "vue": "^3.5.12",
+        "vue-i18n": "^10.0.4",
         "vue-router": "^4.4.5"
       },
       "devDependencies": {
@@ -1152,6 +1153,50 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@intlify/core-base": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-10.0.4.tgz",
+      "integrity": "sha512-GG428DkrrWCMhxRMRQZjuS7zmSUzarYcaHJqG9VB8dXAxw4iQDoKVQ7ChJRB6ZtsCsX3Jse1PEUlHrJiyQrOTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/message-compiler": "10.0.4",
+        "@intlify/shared": "10.0.4"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-10.0.4.tgz",
+      "integrity": "sha512-AFbhEo10DP095/45EauinQJ5hJ3rJUmuuqltGguvc3WsvezZN+g8qNHLGWKu60FHQVizMrQY7VJ+zVlBXlQQkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "10.0.4",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-10.0.4.tgz",
+      "integrity": "sha512-ukFn0I01HsSgr3VYhYcvkTCLS7rGa0gw4A4AMpcy/A9xx/zRJy7PS2BElMXLwUazVFMAr5zuiTk3MQeoeGXaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -5823,6 +5868,26 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/vue-i18n": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-10.0.4.tgz",
+      "integrity": "sha512-1xkzVxqBLk2ZFOmeI+B5r1J7aD/WtNJ4j9k2mcFcQo5BnOmHBmD7z4/oZohh96AAaRZ4Q7mNQvxc9h+aT+Md3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "10.0.4",
+        "@intlify/shared": "10.0.4",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/vue-router": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "vue": "^3.5.12",
+    "vue-i18n": "^10.0.4",
     "vue-router": "^4.4.5"
   },
   "devDependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,7 +14,7 @@ import HelloWorld from './components/HelloWorld.vue'
     />
 
     <div class="wrapper">
-      <HelloWorld msg="You did it!" />
+      <HelloWorld :msg="$t('appName')" />
 
       <nav>
         <RouterLink to="/">Home</RouterLink>

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -8,10 +8,7 @@ defineProps<{
   <div class="greetings">
     <h1 class="green">{{ msg }}</h1>
     <h3>
-      You’ve successfully created a project with
-      <a href="https://vite.dev/" target="_blank" rel="noopener">Vite</a> +
-      <a href="https://vuejs.org/" target="_blank" rel="noopener">Vue 3</a>.
-      What's next?
+      {{ $t('description') }}
     </h3>
   </div>
 </template>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,4 @@
+{
+  "appName": "Bitbot",
+  "description": "Your Trading Bot as a service platform"
+}

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1,0 +1,4 @@
+{
+  "appName": "Bitbot",
+  "description": "Votre plateforme de bot de trading"
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,8 +4,19 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
 
+import { createI18n } from 'vue-i18n'
+import en from './locales/en.json'
+import fr from './locales/fr.json'
+
+const i18n = createI18n({
+  locale: "fr",
+  fallbackLocale: "en",
+  messages: { en, fr }
+})
+
 const app = createApp(App)
 
 app.use(router)
 
+app.use(i18n)
 app.mount('#app')


### PR DESCRIPTION
# Context

We need to easily manage translations. We can start with managing 🇬🇧 + 🇫🇷 

# Solution

* Added [vue-i18n](https://vue-i18n.intlify.dev/), the most used/recommended library in Vue ecosystem
* Created locale files with basic translations _appName_ + _description_

# Tests / QA

1. `npm i`
2. `npm run dev`
3. Make sure the translations appear correctly