### PR TITLE
feat(components): Add first iteration for `Button` component

### DIFF
--- a/src/components/controls/Button.vue
+++ b/src/components/controls/Button.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { ButtonProps } from './types'
+
+const { text, variant, href, to, fit, isDisabled, ...otherProps } =
+  defineProps<ButtonProps>()
+
+const isLink = !!href
+const isRouterLink = !!to
+
+// TODO Enrich this object when we'll support several size for the component
+const sizeDependentCssClasses = {
+  'py-2': true,
+  'rounded-2xl': true,
+}
+
+const secondaryVariant = {
+  'bg-white shadow-2xl border border-solid border-4 border-slate-900': true,
+}
+
+const cssClasses = {
+  'text-center block': true,
+  ...sizeDependentCssClasses,
+  'w-full': fit === 'parent',
+  'bg-amber-500': variant === 'primary',
+  ...(variant === 'secondary' ? secondaryVariant : {}),
+  'pointer-events-none': isLink && isDisabled,
+}
+</script>
+
+<template>
+  <a v-if="isLink" :href="href" :class="cssClasses">{{ text }}</a>
+  <RouterLink v-else-if="isRouterLink" :class="cssClasses" :to="to">{{
+    text
+  }}</RouterLink>
+  <button v-else type="button" :disabled="isDisabled" :class="cssClasses">
+    {{ text }}
+  </button>
+</template>

--- a/src/components/controls/types.ts
+++ b/src/components/controls/types.ts
@@ -1,0 +1,8 @@
+export type ButtonProps = {
+  text: string
+  variant: 'primary' | 'secondary'
+  href?: string
+  to?: string
+  fit?: 'content' | 'parent'
+  isDisabled?: boolean
+}

--- a/src/views/LandingPageView.vue
+++ b/src/views/LandingPageView.vue
@@ -1,4 +1,6 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import Button from '../components/controls/Button.vue'
+</script>
 
 <template>
   <main
@@ -12,11 +14,12 @@
       <img src="" class="text-xs" :alt="$t('landingPage.steps.third')" />
     </div>
     <div class="px-6 w-full">
-      <RouterLink
-        class="block text-center py-2 w-full rounded-2xl bg-amber-500 shadow-2xl"
+      <Button
+        variant="primary"
+        :text="$t('landingPage.cta')"
+        fit="parent"
         to="/login"
-        >{{ $t('landingPage.cta') }}</RouterLink
-      >
+      />
     </div>
   </main>
 </template>


### PR DESCRIPTION
Supports 3 kinds of HTML elements: `a`, `button` and `RouterLink` from Vue Router

For now, the following properties are managed:
* text
* variant: either _primary_ (yellow background) or _secondary_ (white background with border)
* href (optional): to render an anchor
* to (optional): to render a RouterLink (using this component prevents page reloading)
* fit (optional): `content` or  `parent`
* isDisabled (optional)