### PR TITLE
feat(i18n): Handle lang via url query param

### DIFF
--- a/src/locales/i18n.ts
+++ b/src/locales/i18n.ts
@@ -1,0 +1,16 @@
+import { createI18n } from 'vue-i18n'
+
+import en from './en.json'
+import fr from './fr.json'
+
+export const FALLBACK_LOCALE = "en";
+
+export const i18n = createI18n({
+  locale: "en",
+  fallbackLocale: FALLBACK_LOCALE,
+  messages: { en, fr }
+})
+
+export type AvailableLocales = typeof i18n.global.availableLocales[number]
+
+export const isValidLang = (lang: string): lang is AvailableLocales => (i18n.global.availableLocales as string[]).includes(lang)

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,16 +3,8 @@ import './assets/styles/main.css'
 import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
+import { i18n } from './locales/i18n'
 
-import { createI18n } from 'vue-i18n'
-import en from './locales/en.json'
-import fr from './locales/fr.json'
-
-const i18n = createI18n({
-  locale: "fr",
-  fallbackLocale: "en",
-  messages: { en, fr }
-})
 
 const app = createApp(App)
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import LandingPageView from '../views/LandingPageView.vue'
+import { updateLocale } from './updateLocale'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -20,6 +21,16 @@ const router = createRouter({
       component: () => import('../views/AboutView.vue'),
     },
   ],
+})
+
+router.beforeEach(({ query }, from, next) => {
+  const langFromQuery = query.lang
+  if (langFromQuery) {
+    const value = Array.isArray(langFromQuery) ? langFromQuery.pop() : langFromQuery
+    value && updateLocale(value)
+  }
+
+  next()
 })
 
 export default router

--- a/src/router/updateLocale.ts
+++ b/src/router/updateLocale.ts
@@ -1,0 +1,9 @@
+import { FALLBACK_LOCALE, i18n, type AvailableLocales, isValidLang } from '@/locales/i18n'
+
+export const updateLocale = (lang: string) => {
+  const newLang = isValidLang(lang) ? lang : FALLBACK_LOCALE
+
+  if (i18n.global.locale !== newLang) {
+    i18n.global.locale = newLang
+  }
+}


### PR DESCRIPTION
# Context

We need a quick way to update the language. We can first support it via query param like `?lang=en|fr`
If the lang is not supported, we fall back to _en_

# Solution

Use a navigation guard

Took the opportunity to breakdown the _main.ts_ by extracting i18n config into its own file

### Side note

It could be a good opportunity to introduce some quick unit test 🧠 
Use cases to cover:
1. `?lang=fr` ➡️ Renders 🇫🇷  translations
2. `?lang=en` ➡️ Renders 🇬🇧  translations
3. `?lang=pl` ➡️ Fuck the Polish, we don't support this locale, renders 🇬🇧 translations